### PR TITLE
Reformat all PHP files to be PSR-2 and PSR-4 compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v1.4.0]
+This version is compatible with [SimpleSAMLphp v1.17](https://simplesamlphp.org/docs/1.17/simplesamlphp-changelog)
+
+### Changed
+- Code reformatted to PSR-2
+- Declare module's class under SimpleSAML\Module namespace
+
+## [v1.3.0]
+This version is compatible with [SimpleSAMLphp v1.14](https://simplesamlphp.org/docs/1.14/simplesamlphp-changelog)
+
+### Added
+- PersistentNameID2Attribute class
+  - Generates an attribute from the persistent NameID
+- Skip filter when attribute is already set
+
+### Changed
+- Include IdP DisplayName in error page
+- Use PSR-2 coding rules
+
+## [v1.2.0]
+This version is compatible with [SimpleSAMLphp v1.14](https://simplesamlphp.org/docs/1.14/simplesamlphp-changelog)
+
+### Added
+- Use last authority value in case of IdP proxies
+
+## [v1.1.0]
+This version is compatible with [SimpleSAMLphp v1.14](https://simplesamlphp.org/docs/1.14/simplesamlphp-changelog)
+
+### Added
+- Use template for error page
+- Support for SAML 2.0 Persistent NameIDs/ePTIDs
+
+## [v1.0.0]
+This version is compatible with [SimpleSAMLphp v1.14](https://simplesamlphp.org/docs/1.14/simplesamlphp-changelog)
+
+### Added
+- OpaqueSmartID class
+  - Provides consistent user identifiers

--- a/README.md
+++ b/README.md
@@ -63,20 +63,20 @@ SHA-256(AttributeName:AttributeValue!AuthenticatingAuthority!SecretSalt)@scope
 ### Example configuration:
  
 ```
-authproc = array(
+authproc = [
     ...
-    '60' => array(
+    '60' => [
         'class' => 'uid:OpaqueSmartID',
-        'candidates' => array(
+        'candidates' => [
             'eduPersonUniqueId',
             'eduPersonPrincipalName',
             'eduPersonTargetedID',
-        ),
+        ],
         'id_attribute' => 'eduPersonUniqueId',
         'add_candidate' => false,
         'add_authority' => true,   
         'scope' => 'example.org',
-    ),
+    ],
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ authproc = [
     ],
 ```
 
+## Compatibility matrix
+
+This table matches the module version with the supported SimpleSAMLphp version.
+| Module |  SimpleSAMLphp |
+|:------:|:--------------:|
+| v1.0.0 | v1.14          |
+| v1.1.0 | v1.14          |
+| v1.2.0 | v1.14          |
+| v1.3.0 | v1.14          |
+| v1.4.0 | v1.17          |
+
 ## License
 
 Licensed under the Apache 2.0 license, for details see `LICENSE`.

--- a/lib/Auth/Process/OpaqueSmartID.php
+++ b/lib/Auth/Process/OpaqueSmartID.php
@@ -88,7 +88,8 @@ use SimpleSAML\Utils\Config;
  *
  * @author Nicolas Liampotis <nliam@grnet.gr>
  */
-class OpaqueSmartID extends \SimpleSAML\Auth\ProcessingFilter {
+class OpaqueSmartID extends \SimpleSAML\Auth\ProcessingFilter
+{
 
     /**
      * The list of candidate attribute(s) to be used for the new ID attribute.
@@ -132,7 +133,8 @@ class OpaqueSmartID extends \SimpleSAML\Auth\ProcessingFilter {
     private $setUserIdAttribute = true;
 
 
-    public function __construct($config, $reserved) {
+    public function __construct($config, $reserved)
+    {
         parent::__construct($config, $reserved);
 
         assert('is_array($config)');
@@ -185,7 +187,8 @@ class OpaqueSmartID extends \SimpleSAML\Auth\ProcessingFilter {
      *
      * @param array &$request  The request to process
      */
-    public function process(&$request) {
+    public function process(&$request)
+    {
         assert('is_array($request)');
         assert('array_key_exists("Attributes", $request)');
 
@@ -207,7 +210,8 @@ class OpaqueSmartID extends \SimpleSAML\Auth\ProcessingFilter {
             '%RESTARTURL%' => $request[State::RESTART]));
     }
 
-    private function generateUserId($attributes, $request) {
+    private function generateUserId($attributes, $request)
+    {
         foreach ($this->candidates as $idCandidate) {
             if (empty($attributes[$idCandidate][0])) {
                 continue;
@@ -259,7 +263,7 @@ class OpaqueSmartID extends \SimpleSAML\Auth\ProcessingFilter {
             } else {
                 throw new \Exception('Unsupported NameID format');
             }
-        } else     {
+        } else {
             throw new \Exception('Unsupported attribute value type: '
                 . get_class($attribute));
         }

--- a/lib/Auth/Process/OpaqueSmartID.php
+++ b/lib/Auth/Process/OpaqueSmartID.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace SimpleSAML\Module\userid\Auth\Process;
+
 /**
  * A SimpleSAMLphp authentication processing filter for generating long-lived, 
  * non-reassignable, non-targeted, opaque and globally unique user identifiers
@@ -79,7 +81,7 @@
  *
  * @author Nicolas Liampotis <nliam@grnet.gr>
  */
-class sspmod_userid_Auth_Process_OpaqueSmartID extends SimpleSAML_Auth_ProcessingFilter {
+class OpaqueSmartID extends \SimpleSAML\Auth\ProcessingFilter {
 
     /**
      * The list of candidate attribute(s) to be used for the new ID attribute.

--- a/lib/Auth/Process/OpaqueSmartID.php
+++ b/lib/Auth/Process/OpaqueSmartID.php
@@ -71,20 +71,20 @@ use SimpleSAML\Utils\Config;
  * 
  * Example configuration:
  *
- *    authproc = array(
+ *    authproc = [
  *       ...
- *       '60' => array(
+ *       '60' => [
  *           'class' => 'uid:OpaqueSmartID',
- *           'candidates' => array(
+ *           'candidates' => [
  *               'eduPersonUniqueId',
  *               'eduPersonPrincipalName',
  *               'eduPersonTargetedID',
- *           ),
+ *           ],
  *           'id_attribute' => 'eduPersonUniqueId',
  *           'add_candidate' => false,
  *           'add_authority' => true,
  *           'scope' => 'example.org',
- *       ),
+ *       ],
  *
  * @author Nicolas Liampotis <nliam@grnet.gr>
  */
@@ -94,7 +94,7 @@ class OpaqueSmartID extends \SimpleSAML\Auth\ProcessingFilter
     /**
      * The list of candidate attribute(s) to be used for the new ID attribute.
      */
-    private $candidates = array(
+    private $candidates = [
         'eduPersonUniqueId',
         'eduPersonPrincipalName',
         'eduPersonTargetedID',
@@ -103,7 +103,7 @@ class OpaqueSmartID extends \SimpleSAML\Auth\ProcessingFilter
         'facebook_targetedID',
         'windowslive_targetedID',
         'twitter_targetedID',
-    );
+    ];
 
     /**
      * The name of the generated ID attribute.
@@ -195,7 +195,7 @@ class OpaqueSmartID extends \SimpleSAML\Auth\ProcessingFilter
         $userId = $this->generateUserId($request['Attributes'], $request);
 
         if (isset($userId)) {
-            $request['Attributes'][$this->idAttribute] = array($userId);
+            $request['Attributes'][$this->idAttribute] = [$userId];
             // TODO: Remove this in SSP 2.0
             if ($this->setUserIdAttribute) {
                 $request['UserID'] = $userId;
@@ -203,11 +203,12 @@ class OpaqueSmartID extends \SimpleSAML\Auth\ProcessingFilter
             return;
         }
         $baseUrl = Configuration::getInstance()->getString('baseurlpath');
-        $this->showError('NOATTRIBUTE', array(
+        $this->showError('NOATTRIBUTE', [
             '%ATTRIBUTES%' => $this->candidates,
             '%IDP%' => $this->getIdPDisplayName($request),
             '%BASEDIR%' => $baseUrl,
-            '%RESTARTURL%' => $request[State::RESTART]));
+            '%RESTARTURL%' => $request[State::RESTART]
+        ]);
     }
 
     private function generateUserId($attributes, $request)

--- a/lib/Auth/Process/PersistentNameID2Attribute.php
+++ b/lib/Auth/Process/PersistentNameID2Attribute.php
@@ -2,6 +2,8 @@
 
 namespace SimpleSAML\Module\userid\Auth\Process;
 
+use SimpleSAML\Logger;
+
 /**
  * Authentication processing filter for generating an attribute from the persistent NameID.
  *
@@ -65,7 +67,7 @@ class PersistentNameID2Attribute extends \SimpleSAML\Auth\ProcessingFilter
         }
 
         if (!isset($state['saml:sp:NameID']) || $state['saml:sp:NameID']['Format'] !== SAML2_Const::NAMEID_PERSISTENT) {
-            SimpleSAML_Logger::warning(
+            Logger::warning(
                 'Unable to generate ' . $this->attribute 
                 . ' attribute because no persistent NameID was available.'
             );

--- a/lib/Auth/Process/PersistentNameID2Attribute.php
+++ b/lib/Auth/Process/PersistentNameID2Attribute.php
@@ -1,12 +1,13 @@
 <?php
 
+namespace SimpleSAML\Module\userid\Auth\Process;
 
 /**
  * Authentication processing filter for generating an attribute from the persistent NameID.
  *
  * @package SimpleSAMLphp
  */
-class sspmod_userid_Auth_Process_PersistentNameID2Attribute extends SimpleSAML_Auth_ProcessingFilter
+class PersistentNameID2Attribute extends \SimpleSAML\Auth\ProcessingFilter
 {
 
     /**

--- a/lib/Auth/Process/PersistentNameID2Attribute.php
+++ b/lib/Auth/Process/PersistentNameID2Attribute.php
@@ -86,6 +86,6 @@ class PersistentNameID2Attribute extends \SimpleSAML\Auth\ProcessingFilter
             $value = $nameID['Value'];
         }
 
-        $state['Attributes'][$this->attribute] = array($value);
+        $state['Attributes'][$this->attribute] = [$value];
     }
 }


### PR DESCRIPTION
- Switch classes to use namespaces
- Add use declarations to classes
- Change coding style based on PSR-2
  - Opening braces for classes and functions go on the next line
  - Remove left over whitespaces
- Apply modern array syntax to all files