### PR TITLE
Feature required attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpaqueSmartID class
   - List of tags that should be excluded from the authority part of the user id source.
 - Add instructions for `PersistentNameID2Attribute` class
+- Add `RequiredAttributes` class
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- OpaqueSmartID class
+  - List of tags that should be excluded from the authority part of the user id source.
+
 ## [v1.0.0] - 2019-09-10
 
 This version is compatible with [SimpleSAMLphp v1.14](https://simplesamlphp.org/docs/1.14/simplesamlphp-changelog)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpaqueSmartID class
   - List of tags that should be excluded from the authority part of the user id source.
 
+### Changed
+
+- Required changes to support SimpleSAMLphp v1.15
+
 ## [v1.0.0] - 2019-09-10
 
 This version is compatible with [SimpleSAMLphp v1.14](https://simplesamlphp.org/docs/1.14/simplesamlphp-changelog)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - OpaqueSmartID class
   - List of tags that should be excluded from the authority part of the user id source.
+- Add instructions for `PersistentNameID2Attribute` class
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,39 @@ authproc = array(
     ),
 ```
 
+## RequiredAttributes
+
+The `userid:RequiredAttributes` is a SimpleSAMLphp authentication processing filter for making attribute(s) mandatory.
+If the IdP doesn't release these attributes then the authentication chain will stop with an error message displayed in the UI.
+
+
+### Configuration
+
+The following configuration options are available:
+
+* `attributes`: Optional, an array of attributes names which define the required attributes. Default values: givenName, sn, mail
+* `custom_resolutions`: Optional, an array of entity IDs as keys and the custom error message as values . Defaults to empty array.
+
+### Example configuration
+
+```php
+  authproc = array(
+      ...
+      '62' => array(
+          'class' => 'userid:RequiredAttributes',
+          'attributes' => array(
+              'givenName',
+              'sn',
+              'mail',
+              'eduPersonScopedAffiliation',
+          ),
+          'custom_resolutions' => array(
+              'https://www.example1.org/' => 'Error message foo',
+              'https://www.example2.org/' => 'Error message foo bar',
+          ),
+      ),
+```
+
 ## Compatibility matrix
 
 This table matches the module version with the supported SimpleSAMLphp version.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ identifier is generated using the first non-empty attribute from a given
 list of attributes. At least one non-empty attribute is required, otherwise
 authentication fails with an exception.
 
+## OpaqueSmartID
+
 This filter is based on the `smartattributes:SmartID` authentication
 processing filter included in the SimpleSAMLphp distribution. As such,
 it can be used to provide consistent user identifiers when there are 
@@ -19,7 +21,7 @@ following identifier properties:
    in an opaque 64-character long string that by itself provides no information about
    the identified user.
    
-## Configuration
+### Configuration
 The following configuration options are available:
  * `candidates`: An array of attributes names to consider as the user 
    identifier attribute. Defaults to:
@@ -88,6 +90,29 @@ authproc = array(
             'example1',
             'example2',
         ),
+    ),
+```
+
+## PersistentNameID2Attribute
+
+The `userid:PersistentNameID2Attribute` is a SimpleSAMLphp authentication processing filter for generating an attribute from the persistent NameID.
+
+### Configuration
+
+The following configuration options are available:
+
+* `attribute`: Optional, a string to define the attribute name to save the NameID in. Defaults to `eduPersonTargetedID`
+* `nameId`: Optional, a boolean to indicate whether or not to insert `NameID` attribute as a \SAML2\XML\saml\NameID object. Defaults to `true`.
+
+### Example configuration
+
+```php
+authproc = array(
+    ...
+    '61' => array(
+        'class' => 'userid:PersistentNameID2Attribute',
+        'attribute' => 'eduPersonTargetedID',
+        'nameId' => true,
     ),
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The following configuration options are available:
     not available.
  * `skip_authority_list`: Optional, an array of IdP entityIDs that should be 
     excluded from the authority part of the user id source.
+ * `skip_tag_list`: Optional, an array of tags that should be 
+    excluded from the authority part of the user id source.
  
 The generated identifiers have the following form:
 ```
@@ -81,6 +83,10 @@ authproc = array(
         'skip_authority_list' => array(
             'https://www.example1.org',
             'https://www.example2.org',
+        ),
+        'skip_tag_list' => array(
+            'example1',
+            'example2',
         ),
     ),
 ```

--- a/dictionaries/error.definition.json
+++ b/dictionaries/error.definition.json
@@ -1,6 +1,18 @@
 {
+	"descr_NOIDENTIFIER": {
+		"en": "%IDPNAME% does not return a persistent identifier to help us uniquely identify you"
+	},
+	"descr_MISSINGATTRIBUTE": {
+		"en": "%IDPNAME% does not return the required attributes"
+	},
 	"header": {
 		"en": "User identification error"
+	},
+	"helptitle": {
+		"en": "What can you do?"
+	},
+	"helpmessage": {
+		"en": "At the moment, try another way to log in.<br/>For the future, ask your institution administrator to release the required information (send them a print screen of this error, or ask them to contact our support)."
 	},
 	"title": {
 		"en": "Oops! Something went wrong"

--- a/lib/Auth/Process/OpaqueSmartID.php
+++ b/lib/Auth/Process/OpaqueSmartID.php
@@ -248,18 +248,18 @@ class sspmod_userid_Auth_Process_OpaqueSmartID extends SimpleSAML_Auth_Processin
             try {
                 $idValue = $this->parseUserId($attributes[$idCandidate][0]);
             } catch(Exception $e) {
-                SimpleSAML_Logger::warning("Failed to generate user ID based on candidate "
+                SimpleSAML\Logger::warning("Failed to generate user ID based on candidate "
                     . $idCandidate . " attribute: " . $e->getMessage());
                 continue;
             }
-            SimpleSAML_Logger::debug("[OpaqueSmartID] Generating opaque user ID based on "
+            SimpleSAML\Logger::debug("[OpaqueSmartID] Generating opaque user ID based on "
                 . $idCandidate . ': ' . $idValue);
             $authority = null;
             if ($this->addAuthority) {
                 $authority = $this->getAuthority($request);
             }
             if (!empty($authority) && !in_array($authority, $this->skipAuthorityList, true)) {
-                SimpleSAML_Logger::debug("[OpaqueSmartID] authority=" . var_export($authority, true));
+                SimpleSAML\Logger::debug("[OpaqueSmartID] authority=" . var_export($authority, true));
                 $smartID = ($this->addCandidate ? $idCandidate.':' : '') . $idValue . '!' . $authority;
             } else {
                 $smartID = ($this->addCandidate ? $idCandidate.':' : '') . $idValue;

--- a/lib/Auth/Process/PersistentNameID2Attribute.php
+++ b/lib/Auth/Process/PersistentNameID2Attribute.php
@@ -63,26 +63,17 @@ class sspmod_userid_Auth_Process_PersistentNameID2Attribute extends SimpleSAML_A
             return;
         }
 
-        if (!isset($state['saml:sp:NameID']) || $state['saml:sp:NameID']['Format'] !== SAML2_Const::NAMEID_PERSISTENT) {
-            SimpleSAML_Logger::warning(
+        if (!isset($state['saml:sp:NameID']) || $state['saml:sp:NameID']->Format !== \SAML2\Constants::NAMEID_PERSISTENT) {
+            SimpleSAML\Logger::warning(
                 'Unable to generate ' . $this->attribute 
                 . ' attribute because no persistent NameID was available.'
             );
             return;
         }
 
+        // @var \SAML2\XML\saml\NameID $nameID
         $nameID = $state['saml:sp:NameID'];
 
-        if ($this->nameId) {
-            $doc = SAML2_DOMDocumentFactory::create();
-            $root = $doc->createElement('root');
-            $doc->appendChild($root);
-            SAML2_Utils::addNameId($root, $nameID);
-            $value = $doc->saveXML($root->firstChild);
-        } else {
-            $value = $nameID['Value'];
-        }
-
-        $state['Attributes'][$this->attribute] = array($value);
+        $state['Attributes'][$this->attribute] = array((!$this->nameId) ? $nameID->value : $nameID);
     }
 }

--- a/lib/Auth/Process/PersistentNameID2Attribute.php
+++ b/lib/Auth/Process/PersistentNameID2Attribute.php
@@ -3,7 +3,17 @@
 
 /**
  * Authentication processing filter for generating an attribute from the persistent NameID.
+ * 
+ * Example configuration:
  *
+ *    authproc = array(
+ *       ...
+ *       '61' => array(
+ *           'class' => 'userid:PersistentNameID2Attribute',
+ *           'attribute' => 'eduPersonTargetedID',
+ *           'nameId' => true,
+ *       ),
+ * 
  * @package SimpleSAMLphp
  */
 class sspmod_userid_Auth_Process_PersistentNameID2Attribute extends SimpleSAML_Auth_ProcessingFilter
@@ -18,7 +28,7 @@ class sspmod_userid_Auth_Process_PersistentNameID2Attribute extends SimpleSAML_A
 
 
     /**
-     * Whether we should insert it as a saml:NameID element.
+     * Whether we should insert it as a \SAML2\XML\saml\NameID object.
      *
      * @var boolean
      */

--- a/lib/Auth/Process/RequiredAttributes.php
+++ b/lib/Auth/Process/RequiredAttributes.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * This is a SimpleSAMLphp authentication processing filter for
+ * making attribute(s) mandatory.
+ * If the IdP doesn't release these attributes then the authentication
+ * chain will stop with an error message displayed in the UI.
+ *
+ * Example configuration:
+ *
+ *    authproc = array(
+ *       ...
+ *       '60' => array(
+ *           'class' => 'userid:RequiredAttributes',
+ *           'attributes' => array(
+ *               'givenName',
+ *               'sn',
+ *               'mail',
+ *               'eduPersonScopedAffiliation',
+ *           ),
+ *           'custom_resolutions' => array(
+ *               'https://www.example1.org/' => 'Error message foo',
+ *               'https://www.example2.org/' => 'Error message foo bar',
+ *           ),
+ *       ),
+ *
+ * @author Nicolas Liampotis <nliam@grnet.gr>
+ */
+
+class sspmod_userid_Auth_Process_RequiredAttributes extends SimpleSAML_Auth_ProcessingFilter
+{
+
+    /**
+     * The list of required attribute(s).
+     */
+    private $attributes = array(
+        'givenName',
+        'sn',
+        'mail',
+    );
+
+    /**
+     * A mapping for entityIDs and custom error message.
+     * It's a list of entityIDs as keys and the messages as values.
+     */
+    private $customResolutions = [];
+
+    public function __construct($config, $reserved) {
+        parent::__construct($config, $reserved);
+
+        assert('is_array($config)');
+
+        if (array_key_exists('attributes', $config)) {
+            $this->attributes = $config['attributes'];
+            if (!is_array($this->attributes)) {
+                throw new Exception('RequiredAttributes authproc configuration error: \'attributes\' should be an array.');
+            }
+        }
+
+        if (array_key_exists('custom_resolutions', $config)) {
+            $this->customResolutions = $config['custom_resolutions'];
+            if (!is_array($this->attributes)) {
+                throw new Exception('RequiredAttributes authproc configuration error: \'custom_resolutions\' should be an array.');
+            }
+        }
+    }
+
+    /**
+     * Process request.
+     *
+     * @param array &$request  The request to process
+     */
+    public function process(&$request) {
+        assert('is_array($request)');
+        assert('array_key_exists("Attributes", $request)');
+
+        $missingAttributes = [];
+        foreach ($this->attributes as $attribute) {
+            if (empty($request['Attributes'][$attribute])) {
+                 $missingAttributes[] = $attribute;
+            }
+        }
+        SimpleSAML\Logger::debug("[RequiredAttributes] missingAttributes=" . var_export($missingAttributes, true));
+        if (empty($missingAttributes)) {
+            return;
+        }
+
+        $idpEntityId = $this->getIdPEntityId($request);
+        $idpMetadata = $this->getIdPMetadata($request);
+        $idpName = $this->getIdPDisplayName($idpMetadata);
+        if (is_null($idpName)) {
+            $idpName = $idpEntityId;
+        }
+        $idpEmailAddress = $this->getIdPEmailAddress($idpMetadata);
+        $baseUrl = SimpleSAML_Configuration::getInstance()->getString('baseurlpath');
+        $errorParams = array(
+            '%ATTRIBUTES%' => $missingAttributes,
+            '%IDPNAME%' => $idpName,
+            '%IDPEMAILADDRESS%' => $idpEmailAddress,
+            '%BASEDIR%' => $baseUrl,
+            '%RESTARTURL%' => $request[SimpleSAML_Auth_State::RESTART]
+        );
+        if (!empty($this->customResolutions["$idpEntityId"])) {
+            $errorParams['%CUSTOMRESOLUTION%'] = $this->customResolutions["$idpEntityId"];
+        }
+        $this->showError('MISSINGATTRIBUTE', $errorParams);
+    }
+
+    private function getIdPEmailAddress($idpMetadata)
+    {
+        $idpEmailAddress = null;
+        if (!empty($idpMetadata['contacts']) && is_array($idpMetadata['contacts'])) {
+            foreach ($idpMetadata['contacts'] as $contact) {
+                if (!empty($contact['contactType']) && !empty($contact['emailAddress'])) {
+                    if ($contact['contactType'] === 'technical') {
+                        $idpEmailAddress = $contact['emailAddress'];
+                        continue;
+                    } elseif ($contact['contactType'] === 'support') {
+                        $idpEmailAddress = $contact['emailAddress'];
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!empty($idpEmailAddress)) {
+            foreach ($idpEmailAddress as &$idpEmailAddressEntry) {
+                if (substr($idpEmailAddressEntry, 0, 7) === "mailto:") {
+                    $idpEmailAddressEntry = substr($idpEmailAddressEntry, 7);
+                }
+            }
+            $idpEmailAddress = implode(";", $idpEmailAddress);
+        }
+        return $idpEmailAddress;
+    }
+
+    private function getIdPDisplayName($idpMetadata)
+    {
+        if (!empty($idpMetadata['UIInfo']['DisplayName'])) {
+            $displayName = $idpMetadata['UIInfo']['DisplayName'];
+            // Should always be an array of language code -> translation
+            assert('is_array($displayName)');
+            // TODO: Use \SimpleSAML\Locale\Translate::getPreferredTranslation()
+            // in SSP 2.0
+            if (!empty($displayName['en'])) {
+                return $displayName['en'];
+            }
+        }
+
+        if (!empty($idpMetadata['name'])) {
+            // TODO: Use \SimpleSAML\Locale\Translate::getPreferredTranslation()
+            // in SSP 2.0
+            if (!empty($idpMetadata['name']['en'])) {
+                return $idpMetadata['name']['en'];
+            } else {
+                return $idpMetadata['name'];
+            }
+        }
+
+        return null;
+    }
+
+    private function getIdPEntityId($request)
+    {
+        assert('array_key_exists("entityid", $request["Source"])');
+
+        // If the module is active on a bridge,
+        // $request['saml:sp:IdP'] will contain an entry id for the remote IdP.
+        if (!empty($request['saml:sp:IdP'])) {
+            return $request['saml:sp:IdP'];
+        } else {
+            return $request['Source']['entityid'];
+        }
+    }
+
+    private function getIdPMetadata($request)
+    {
+        // If the module is active on a bridge,
+        // $request['saml:sp:IdP'] will contain an entry id for the remote IdP.
+        if (!empty($request['saml:sp:IdP'])) {
+            $idpEntityId = $request['saml:sp:IdP'];
+            return SimpleSAML_Metadata_MetaDataStorageHandler::getMetadataHandler()->getMetaData($idpEntityId, 'saml20-idp-remote');
+        } else {
+            return $request['Source'];
+        }
+    }
+
+    private function showError($errorCode, $errorParams)
+    {
+        $globalConfig = SimpleSAML_Configuration::getInstance();
+        $t = new SimpleSAML_XHTML_Template($globalConfig, 'userid:error.tpl.php');
+        $t->data['errorCode'] = $errorCode;
+        $t->data['parameters'] = $errorParams;
+        $t->show();
+        exit();
+    }
+
+}


### PR DESCRIPTION
- OpaqueSmartID class
  - List of tags that should be excluded from the authority part of the user id source.
- Add instructions for `PersistentNameID2Attribute` class
- Add `RequiredAttributes` class
- Make required changes to support SimpleSAMLphp v1.15