### PR TITLE
Add IdP's contact email address in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- OpaqueSmartID class
+  - Include email address of the IdP to the error message
+
 ## [v2.0.0] - 2019-09-13
 
 ### Added


### PR DESCRIPTION
- OpaqueSmartID class
  - Include email address of the IdP to the error message