### PR TITLE
FIx `$request['UserID']` error

### DIFF
--- a/lib/Auth/Process/OpaqueSmartID.php
+++ b/lib/Auth/Process/OpaqueSmartID.php
@@ -318,7 +318,7 @@ class OpaqueSmartID extends ProcessingFilter
             Logger::debug(
                 "[OpaqueSmartID] copyUserId: Copying user ID based on " . $idCandidate . ': ' . $idValue
             );
-            $request['UserID'] = [$idValue];
+            $request['UserID'] = $idValue;
             $request['Attributes'][$this->idAttribute] = [$idValue];
             $request['rciamAttributes']['cuid'] = [$idValue];
             return;


### PR DESCRIPTION
I noticed in the logs that a users that logs in to MITREid using Google IdP get the following error:

```
Dec 22 17:14:06 simplesamlphp-proxy ERROR [230d28629f] SimpleSAML\Error\Exception: Error 2 - strlen() expects parameter 1 to be string, array given at /srv/simplesamlphp/proxy-rciam-1.18/modules/saml/lib/IdP/SAML2.php:969
```
