### PR TITLE
Add support for overriding candidates for specific IdPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ The following configuration options are available:
   - `facebook_targetedID`
   - `windowslive_targetedID`
   - `twitter_targetedID`
+- `authority_candidate_map`: An array of IdP entityIDs which are mapped to
+  specific attributes names to consider for generating the user identifier.
+  Defaults to the empty array. If no IdP in this map matches, then the user
+  identifier is generated based on the attributes specified in `candidates`.
 - `cuid_candidates`: An array of attributes names to consider as the user
   identifier attribute for whitelisted/blacklisted IdP tags. Defaults to:
   - `voPersonID`

--- a/lib/Auth/Process/OpaqueSmartID.php
+++ b/lib/Auth/Process/OpaqueSmartID.php
@@ -151,7 +151,9 @@ class OpaqueSmartID extends ProcessingFilter
         if (array_key_exists('authority_candidate_map', $config)) {
             $this->authorityCandidateMap = $config['authority_candidate_map'];
             if (!is_array($this->authorityCandidateMap)) {
-                throw new Exception('[OpaqueSmartID] authproc configuration error: \'authority_candidate_map\' should be an array.');
+                throw new Exception(
+                    '[OpaqueSmartID] authproc configuration error: \'authority_candidate_map\' should be an array.'
+                );
             }
         }
 


### PR DESCRIPTION
This PR adds a new configuration option for overriding the list of candidate attributes for specific IdPs identified by their SAML entityID.

Example configuration:
```
'authority_candidate_map' => [
    'idp1.example.org' => [
        'eduPersonPrincipalName',
        'subject-id',
    ],
    'idp2.example.org' => [
        'subject-id',
        'eduPersonPrincipalName',
    ],
]
```